### PR TITLE
Adding an example of docker/docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+#
+# Build Loowid Image
+#
+FROM       node:0.10.33
+
+MAINTAINER loowid <loowid@gmail.com>
+
+# Download and install loowid source
+RUN mkdir /opt/loowid
+# Just copy the package file in so that builds are well cached and it doesn't rebuild everything
+COPY package.json /opt/loowid/
+RUN cd /opt/loowid && npm install --production
+
+COPY . /opt/loowid
+
+# Create self signed certificate
+RUN openssl genrsa -out /opt/loowid/private.pem 1024 && \
+    openssl req -new -key /opt/loowid/private.pem -out /opt/loowid/public.csr -subj "/C=ES/ST=None/L=None/O=None/OU=None/CN=localhost" && \
+    openssl x509 -req -days 366 -in /opt/loowid/public.csr -signkey /opt/loowid/private.pem -out /opt/loowid/public.pem
+
+# Expose https port from the container to the host
+EXPOSE 443
+
+# Work directory
+WORKDIR /opt/loowid
+
+# Run server
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Wiki Documentation | Vote us !! | Bitnami Contest
 
 ## Docker
 
-  Too many steps to install? Don't worry LooWID is also dockerized !!
+  Too many steps to install? Don't worry LooWID is also dockerized !! If you have docker and docker-compose installed you can just type:
   
-  https://github.com/loowid/loowid-docker
+    docker-compose up
+
+  This will bring up a copy of MongoDB and LooWID in 2 containers and you can access LooWID on https://{docker-ip/}
   
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+loowid:
+  build: .
+  environment:
+    - MONGOHQ_URL=mongodb://mongodb/loowid
+  links:
+    - mongodb
+  ports:
+    - "443:443"
+  
+mongodb:
+  image: mongo:2.6.11
+  command: mongod --smallfiles
+  


### PR DESCRIPTION
Putting it in the main repository means that incremental builds work well and the building of the containers uses the docker cache to only rebuild what it needs. Using the standard MongoDB image also means that it re-uses other peoples work on keeping the data between MongoDB restarts.